### PR TITLE
Remove setStyle within init which did not allow our own setStyle

### DIFF
--- a/src/datalayerclusterer.js
+++ b/src/datalayerclusterer.js
@@ -1189,8 +1189,6 @@ DataLayerClusterer.prototype.init_ = function() {
     this._dataLayer.forEach(function(feature) {
       feature.setProperty('in_cluster', true);
     });
-  } else {
-    this._dataLayer.setStyle(DataLayerClusterer.HIDDEN_FEATURE);
   }
   if (this.map !== null) {
     this.setMap(this.map);


### PR DESCRIPTION
This change looks to have no negative effects and allows for the use of setStyle to customize marker icons for instance.

Without the change doing something like the following would have no effect and the default pin icon would be used.

```javascript
dataLayer = new DataLayerClusterer({
    "map": map,
    "maxZoom": 15
});

dataLayer.addGeoJson(data);

dataLayer.setStyle(function(feature) {
    var militaryFriendly = feature.getProperty('military_friendly');
    return {
        icon: militaryFriendly === true ? baseURL + 'img/map/university-green.png' : baseURL + 'img/map/university-red.png'
    };
});
```