### PR TITLE
Changed 'featureBounds' method to use 'forEachLatLng'

### DIFF
--- a/src/datalayerclusterer.js
+++ b/src/datalayerclusterer.js
@@ -477,19 +477,7 @@ DataLayerClusterer.prototype.featureBounds_ = function (feature, extendBounds) {
   var geom = feature.getGeometry ? feature.getGeometry() : feature,
       geom_bounds = extendBounds || new google.maps.LatLngBounds();
 
-    if (geom.getType() == 'Point') {
-      geom_bounds.extend(geom.get());
-    } else {
-      geom.getArray().forEach(function (g) {
-        if (g instanceof google.maps.LatLng) {
-          geom_bounds.extend(g);
-        } else {
-          g.getArray().forEach(function (LatLng) {
-            geom_bounds.extend(LatLng);
-          });
-        }
-      });
-    }
+  geom.forEachLatLng(function (latLng) { geom_bounds.extend(latLng); });
     
   return geom_bounds;
 };


### PR DESCRIPTION
I made a change to the 'featureBounds' function, so it would support complex geometries, with more than one level of nesting. It was only traversing one layer of the Geometry's points, when in fact Geometries can have any amount of nesting. One example of complex geometries of this type is the 'MultiPolygon' https://tools.ietf.org/html/rfc7946#section-3.1.7
My change to the function makes it use google's forEachLatLng method, provided for geometries. This method iterates over each LatLng of a geometry, regardless of what kind of geometry it is, and how many layers of geometries and points it contains. I use this method to extend the bounds using each LatLng inside the Geometry.